### PR TITLE
[VIDEO-2852] Build using GHA Built-in Runners

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,11 +11,6 @@ on:
         description: 'Ref to use for Cerbero'
         required: false
         default: fixes-for-cerbero-action
-      bootstrap-system:
-        description: 'Bootstrap the system before building'
-        required: false
-        type: boolean
-        default: true
       no-cache:
         description: 'Do not use cache when building'
         required: false
@@ -38,4 +33,3 @@ jobs:
           cerbero-repo: ${{ inputs.cerbero-repo }}
           cerbero-ref: ${{ inputs.cerbero-ref }}
           no-cache: ${{ inputs.no-cache == true }}
-          bootstrap-system: ${{ inputs.bootstrap-system }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,12 +10,7 @@ on:
       cerbero-ref:
         description: 'Ref to use for Cerbero'
         required: false
-        default: fixes-for-cerbero-action
-      bootstrap-system:
-        description: 'Bootstrap the system before building'
-        required: false
-        type: boolean
-        default: true
+        default: 1.24-lldc
       no-cache:
         description: 'Do not use cache when building'
         required: false
@@ -38,4 +33,3 @@ jobs:
           cerbero-repo: ${{ inputs.cerbero-repo }}
           cerbero-ref: ${{ inputs.cerbero-ref }}
           no-cache: ${{ inputs.no-cache == true }}
-          bootstrap-system: ${{ inputs.bootstrap-system }}

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,6 @@ inputs:
     description: 'Additional args to pass to Cerbero package'
     required: false
     default: ''
-  bootstrap-system:
-    description: 'Bootstrap the system before building'
-    required: false
-    default: 'true'
   cleanup:
     description: 'Whether to clean the Cerbero build directory'
     required: false
@@ -82,6 +78,16 @@ runs:
       run: |
         git clone --depth=1 --branch ${{ inputs.cerbero-ref }} ${{ inputs.cerbero-repo }} cerbero
 
+    - name: Run Bootstrap
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      working-directory: cerbero
+      run: |
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          powershell.exe ./tools/bootstrap-windows.ps1
+        else
+          ./tools/bootstrap-debian.sh
+        fi
+
     - id: version-info
       shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
       working-directory: cerbero
@@ -97,28 +103,6 @@ runs:
 
         echo "runtime-msi-filename=gstreamer-1.0-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
         echo "dev-msi-filename=gstreamer-1.0-devel-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
-
-    - if: ${{inputs.bootstrap-system == 'true' && runner.os == 'Windows' }}
-      name: Bootstrap Windows
-      shell: powershell
-      working-directory: cerbero
-      run: |
-        # Bootstrap Windows
-        ./tools/bootstrap-windows.ps1
-
-    - if: ${{inputs.bootstrap-system == 'true' && runner.os == 'Linux' }}
-      name: Bootstrap Linux
-      shell: bash
-      working-directory: cerbero
-      run: |
-        # Bootstrap Linux
-        sudo apt-get update
-        sudo apt-get -y install --no-install-recommends \
-          sudo \
-          git \
-          python3 \
-          locales \
-          vim
 
     - id: cerbero-config
       working-directory: cerbero
@@ -203,7 +187,7 @@ runs:
         ls -l '${{ steps.cerbero-config.outputs.cerbero-home }}'
         echo "::endgroup::"
 
-    - id: bootstrap-cerbero
+    - id: cerbero-build
       working-directory: cerbero
       shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
       env:
@@ -240,13 +224,13 @@ runs:
         group_cmd "$CERBERO $CERBERO_ARGS build --offline $more_deps" | tee -a "${LOG_PATH}/3_build-deps.log"
         group_cmd "$CERBERO $CERBERO_ARGS gen-cache" | tee "${LOG_PATH}/4_cache.log"
 
-    - if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-sources-cache.outputs.cache-hit }}
+    - if: ${{ inputs.no-cache != 'true' && steps.cerbero-build.outcome == 'success' && ! steps.restore-cerbero-sources-cache.outputs.cache-hit }}
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
         key: ${{ steps.restore-cerbero-sources-cache.outputs.cache-primary-key }}
 
-    - if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
+    - if: ${{ inputs.no-cache != 'true' && steps.cerbero-build.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cerbero-config.outputs.cerbero-home }}/cerbero-deps.tar.xz

--- a/action.yml
+++ b/action.yml
@@ -221,7 +221,7 @@ runs:
         LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
         FETCH_ARGS: --jobs=4
       run: |
-        # Bootstrap Cerbero Log
+        # Bootstrap Cerbero
         mkdir -p "${LOG_PATH}"
 
         group_cmd () {

--- a/action.yml
+++ b/action.yml
@@ -303,3 +303,9 @@ runs:
         name: cerbero-logs
         path: ${{ steps.cerbero-config.outputs.cerbero-home }}/logs
 
+    - name: Upload builddir on build failure
+      uses: actions/upload-artifact@v4
+      if: ${{ always() && steps.build-packages.outcome != 'success' }}
+      with:
+        name: cerbero-build
+        path: ${{ steps.cerbero-config.outputs.cerbero-home }}

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,15 @@ runs:
         New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
     - if: runner.os == 'Windows'
+      # These are seen in the cerbero-uninstalled.ps1 script as a CLI arg
+      name: Set Extra MSYS2 flags for UCRT64 Environment
+      shell: powershell
+      run: |
+        Add-Content "C:\msys64\ucrt64.ini" "`nCHERE_INVOKING=1"
+        Add-Content "C:\msys64\ucrt64.ini" "`nMSYS2_NOSTART=yes"
+        Add-Content "C:\msys64\ucrt64.ini" "`nMSYS=winsymlinks:nativestrict"
+
+    - if: runner.os == 'Windows'
       name: Set Git 'core.autocrlf = false'
       shell: msys2 -eo pipefail {0}
       run: git config --global core.autocrlf false

--- a/action.yml
+++ b/action.yml
@@ -97,9 +97,8 @@ runs:
       shell: msys2 -eo pipefail {0}
       run: git config --global core.autocrlf false
 
-    - id: get-cerbero
+    - name: Clone Cerbero
       shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      name: Get Cerbero
       run: |
         git clone --depth=1 --branch ${{ inputs.cerbero-ref }} ${{ inputs.cerbero-repo }} cerbero
 
@@ -114,6 +113,7 @@ runs:
         fi
 
     - id: version-info
+      name: Gather Version Information
       shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
       working-directory: cerbero
       env:
@@ -130,6 +130,7 @@ runs:
         echo "dev-msi-filename=gstreamer-1.0-devel-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
 
     - id: cerbero-config
+      name: Configure Cerbero Build
       working-directory: cerbero
       shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
       env:
@@ -220,7 +221,7 @@ runs:
         LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
         FETCH_ARGS: --jobs=4
       run: |
-        # Bootstrap Cerbero
+        # Bootstrap Cerbero Log
         mkdir -p "${LOG_PATH}"
 
         group_cmd () {

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,13 @@ runs:
           mingw-w64-ucrt-x86_64-perl
 
     - if: runner.os == 'Windows'
+      name: Enable long file paths
+      shell: powershell
+      run: |
+        New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
+    - if: runner.os == 'Windows'
+      name: Set Git 'core.autocrlf = false'
       shell: msys2 -eo pipefail {0}
       run: git config --global core.autocrlf false
 

--- a/action.yml
+++ b/action.yml
@@ -303,7 +303,3 @@ runs:
         name: cerbero-logs
         path: ${{ steps.cerbero-config.outputs.cerbero-home }}/logs
 
-    - name: Cleanup Cerbero
-      if: ${{ always() && inputs.cleanup == 'true' && steps.get-cerbero.outcome != 'skipped' }}
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      run: rm -rf "cerbero"

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,11 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Python >= 3.10
+      uses: actions/setup-python@v5
+      with:
+        # cerbero requires >=3.10
+        python-version: '>=3.10'
 
     - id: setup-msys2
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -53,13 +53,17 @@ runs:
         # cerbero requires >=3.10
         python-version: '>=3.10'
 
-    - id: setup-msys2
-      if: runner.os == 'Windows'
+    - if: runner.os == 'Windows'
+      name: Setup MSYS2
       uses: msys2/setup-msys2@v2
       with:
-        msystem: UCRT64
+        # release = false: use existing installation
+        # path-type: cerbero requires 'inherit' path type
+        # tie 'cache' to the input arg
+        release:   false
+        msystem:   UCRT64
         path-type: inherit
-        cache: ${{ inputs.no-cache != 'true' }}
+        cache:     ${{ inputs.no-cache != 'true' }}
         install: >-
           mingw-w64-ucrt-x86_64-jq
           m4

--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,7 @@ runs:
         ls -l '${{ steps.cerbero-config.outputs.cerbero-home }}'
         echo "::endgroup::"
 
-    - id: cerbero-build
+    - id: build-gstreamer-deps
       working-directory: cerbero
       shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
       env:
@@ -221,7 +221,7 @@ runs:
         LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
         FETCH_ARGS: --jobs=4
       run: |
-        # Bootstrap Cerbero
+        # Build Cerbero Deps
         mkdir -p "${LOG_PATH}"
 
         group_cmd () {
@@ -250,13 +250,13 @@ runs:
         group_cmd "$CERBERO $CERBERO_ARGS build --offline $more_deps" | tee -a "${LOG_PATH}/3_build-deps.log"
         group_cmd "$CERBERO $CERBERO_ARGS gen-cache" | tee "${LOG_PATH}/4_cache.log"
 
-    - if: ${{ inputs.no-cache != 'true' && steps.cerbero-build.outcome == 'success' && ! steps.restore-cerbero-sources-cache.outputs.cache-hit }}
+    - if: ${{ inputs.no-cache != 'true' && steps.build-gstreamer-deps.outcome == 'success' && ! steps.restore-cerbero-sources-cache.outputs.cache-hit }}
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
         key: ${{ steps.restore-cerbero-sources-cache.outputs.cache-primary-key }}
 
-    - if: ${{ inputs.no-cache != 'true' && steps.cerbero-build.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
+    - if: ${{ inputs.no-cache != 'true' && steps.build-gstreamer-deps.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cerbero-config.outputs.cerbero-home }}/cerbero-deps.tar.xz
@@ -308,5 +308,5 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ always() && steps.build-packages.outcome != 'success' }}
       with:
-        name: cerbero-build
+        name: build-gstreamer-deps
         path: ${{ steps.cerbero-config.outputs.cerbero-home }}

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
           mingw-w64-ucrt-x86_64-diffutils
           flex
           mingw-w64-ucrt-x86_64-gperf
-          mingw-w64-ucrt-x86_64-make
+          mingw-w64-ucrt-x86_64-autotools
           mingw-w64-ucrt-x86_64-ninja
           mingw-w64-ucrt-x86_64-perl
 


### PR DESCRIPTION
This patch set includes changes, which in concert with blinemedical/cerbero#26, enable this github action to build and install GStreamer using GHA runners (tested on `windows-2022` -derived runners).  Some of the key findings:

1. The image includes `msys2`, but it's not on the PATH, so you can't use it as a shell directly.  Using `action/setup-msys2` is imperative then with `release:false` so that any changes will be applied to the already-installed instance rather than adding a second.
2. The `msys2` installation needs to be configured for `path-type:inherit` and `msystem:ucrt64` so that the shell environment remains consistent to the expectations of `cerbero-uninstalled.ps1`'s use of `msys2_command.cmd arguments`.
3. Configuring `msys2` via its `.ini` files to include the above flags ensures every `shell: msys2 ... {0}` is consistent.
4. Configuring `msys2` via its `.ini` files to include `MSYS=winsymlinks:nativestrict` ensures that `actions/upload-artifact` can successfully copy the build directory in the event that artifact is of interest (also prevents MSYS from creating deep copies of files rather than leveraging windows symlinks).
5. Cerbero verifies that python >3.7 is installed but uses features from >=3.10, so that accommodation is made.

Further improvements to be made here are:
1. Make the action capable of detecting if a previous build produced the necessary MSIs and simply skip to providing download paths to them.
2. Make the action reusable externally with an `install` action that installs the MSI(s) for dependent projects, building those MSIs only if necessary.