### PR TITLE
[Chore] Split the action into reusable pieces including "install"

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,233 @@
+name: Build GStreamer via Cerbero
+description: Uses the GStreamer Cerbero build aggregator to build GStreamer on the local toolchain
+inputs:
+  cerbero-package-origin:
+    description: 'Package Origin to set in GStreamer Packages'
+    required: false
+    default: ''
+  config:
+    description: 'Name of the configuration file to use'
+    required: false
+    default: ''
+  cerbero-args:
+    description: 'Additional args to pass to Cerbero'
+    required: false
+    default: ''
+  cerbero-package-args:
+    description: 'Additional args to pass to Cerbero package'
+    required: false
+    default: ''
+  s3-upload-path:
+    description: 'S3 path to upload to'
+    required: false
+  gst-plugins-rs-repo:
+    description: 'Repository to use for gst-plugins-rs'
+    required: false
+  gst-plugins-rs-ref:
+    description: 'Ref/tag to use for gst-plugins-rs'
+    required: false
+  no-cache:
+    description: 'Whether to disable restoring from cache'
+    required: false
+    default: 'false'
+outputs:
+  gstreamer-version:
+    description: 'GStreamer version built'
+    value: ${{ steps.cerbero-config.outputs.version }}
+  runtime-installer-path:
+    description: 'Location of the GStreamer runtime installer'
+    value: ${{ steps.build-packages.outputs.runtime-msi }}
+  devel-installer-path:
+    description: 'Location of the GStreamer development installer'
+    value: ${{ steps.build-packages.outputs.dev-msi }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run Bootstrap Script
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      working-directory: cerbero
+      run: |
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          powershell.exe ./tools/bootstrap-windows.ps1
+        else
+          ./tools/bootstrap-debian.sh
+        fi
+
+    - id: cerbero-config
+      working-directory: cerbero
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      env:
+        CERBERO_PATH: cerbero
+        CERBERO_HOME: cerbero-build
+        CERBERO_SOURCES: cerbero-sources
+        CERBERO: "./cerbero-uninstalled -c config/${{ inputs.config }} -c localconf.cbc"
+        CERBERO_ARGS: ${{ inputs.cerbero-args }}
+        CERBERO_PACKAGE_ARGS: ${{ inputs.cerbero-package-args }}
+        CERBERO_PACKAGE_ORIGIN: ${{ inputs.cerbero-package-origin }}
+        GST_PLUGINS_RS_SOURCE: ${{ inputs.gst-plugins-rs-repo }}
+        GST_PLUGINS_RS_REF: ${{ inputs.gst-plugins-rs-ref }}
+      run: |
+        # Set up Cerbero configuration
+        echo "cerbero-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+        echo "cerbero-home=${CERBERO_PATH}\\${CERBERO_HOME}" >> $GITHUB_OUTPUT
+        echo "cerbero-sources=${CERBERO_PATH}\\${CERBERO_SOURCES}" >> $GITHUB_OUTPUT
+        echo "full-log-path=$(cygpath -au .)/${CERBERO_HOME}/logs" >> $GITHUB_OUTPUT
+
+        pwd_native=$(cygpath -am .)
+        echo "home_dir = \"${pwd_native}/${CERBERO_HOME}\"" > localconf.cbc
+        echo "local_sources = \"${pwd_native}/${CERBERO_SOURCES}\"" >> localconf.cbc
+        echo "vs_install_version = \"vs17\"" >> localconf.cbc
+        echo "num_of_cpus = ${NUMBER_OF_PROCESSORS}" >> localconf.cbc
+        echo "package_origin = \"${CERBERO_PACKAGE_ORIGIN}\"" >> localconf.cbc
+
+        # Handle custom gst-plugins-rs provider
+        if [ -n "${GST_PLUGINS_RS_SOURCE}" ] && [ -n "${GST_PLUGINS_RS_REF}" ]; then
+          echo "recipes_remotes = {'gst-plugins-rs': {'patched': '${GST_PLUGINS_RS_SOURCE}'}}" >> localconf.cbc
+          echo "recipes_commits = {'gst-plugins-rs': '${GST_PLUGINS_RS_REF}'}" >> localconf.cbc
+        fi
+        cat localconf.cbc
+
+        git clean -xdf -e localconf.cbc -e "${CERBERO_SOURCES}"
+
+        echo "CERBERO=${CERBERO}" >> $GITHUB_ENV
+        echo "CERBERO_ARGS=${CERBERO_ARGS}" >> $GITHUB_ENV
+        echo "CERBERO_PACKAGE_ARGS=${CERBERO_PACKAGE_ARGS}" >> $GITHUB_ENV
+
+        config_hash=$(echo "${CERBERO_ARGS}${{ inputs.config }}${GST_PLUGINS_RS_SOURCE}${GST_PLUGINS_RS_REF}" | sha256sum | cut -d' ' -f1)
+        echo "config-hash=${config_hash}" >> $GITHUB_OUTPUT
+
+        # Get GStreamer version from cerbero
+        echo "version=$(./cerbero-uninstalled packageinfo gstreamer-1.0 | awk '/Version:/ {print $2}')" >> $GITHUB_OUTPUT
+
+    - id: restore-cerbero-sources-cache
+      if: ${{ inputs.no-cache != 'true' }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
+        key: |
+          cerbero-sources-${{ steps.cerbero-config.outputs.version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}
+        restore-keys: |
+          cerbero-sources-${{ steps.cerbero-config.outputs.version }}-
+          cerbero-sources-
+
+    - id: restore-cerbero-deps-cache
+      if: ${{ inputs.no-cache != 'true' }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
+        key: |
+          ${{ runner.os }}-cerbero-deps-${{ steps.cerbero-config.outputs.version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ steps.cerbero-config.outputs.config-hash }}-${{ runner.name }}
+        restore-keys: |
+          ${{ runner.os }}-cerbero-deps-${{ steps.cerbero-config.outputs.version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ steps.cerbero-config.outputs.config-hash }}-
+
+    - if: ${{ steps.restore-cerbero-deps-cache.outputs.cache-matched-key }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        # Restore Cerbero dependencies
+        deps_file='${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz'
+
+        if [ ! -f "$deps_file" ]; then
+          exit 0
+        fi
+
+        echo "::group::Unpacking Cerbero Deps"
+        tar -xJf "${deps_file}" -C '${{ steps.cerbero-config.outputs.cerbero-home }}'
+        rm -f "${deps_file}"
+        ls -l '${{ steps.cerbero-config.outputs.cerbero-home }}'
+        echo "::endgroup::"
+
+    - id: build-gstreamer-deps
+      working-directory: cerbero
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      env:
+        CI_PROJECT_NAME: cerbero
+        LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
+        FETCH_ARGS: --jobs=4
+      run: |
+        # Bootstrap Cerbero
+        mkdir -p "${LOG_PATH}"
+
+        group_cmd () {
+          echo "::group::$1"
+          eval $1
+          echo "::endgroup::"
+        }
+
+        group_cmd "pacman -Q" | tee "${LOG_PATH}/0_pacman.log"
+
+        # Build deps for all gstreamer recipes and any recipes that build gstreamer
+        # plugins (and hence compile against gstreamer)
+        build_deps="gstreamer-1.0 gst-plugins-base-1.0 gst-plugins-good-1.0
+            gst-plugins-bad-1.0 gst-plugins-ugly-1.0 gst-rtsp-server-1.0
+            gst-devtools-1.0 gst-editing-services-1.0 libnice gst-plugins-rs
+            gst-libav-1.0"
+        more_deps="glib-networking pkg-config"
+
+        group_cmd "$CERBERO $CERBERO_ARGS show-config" | tee "${LOG_PATH}/1_config.log"
+        group_cmd "$CERBERO $CERBERO_ARGS fetch-bootstrap $FETCH_ARGS" | tee "${LOG_PATH}/2_bootstrap.log"
+        group_cmd "$CERBERO $CERBERO_ARGS fetch-package $FETCH_ARGS --deps gstreamer-1.0" | tee -a "${LOG_PATH}/2_bootstrap.log"
+        group_cmd "$CERBERO $CERBERO_ARGS bootstrap --offline --system=no" | tee -a "${LOG_PATH}/2_bootstrap.log"
+        group_cmd "$CERBERO $CERBERO_ARGS build-deps --offline $build_deps" | tee "${LOG_PATH}/3_build-deps.log"
+        group_cmd "$CERBERO $CERBERO_ARGS build --offline $more_deps" | tee -a "${LOG_PATH}/3_build-deps.log"
+        group_cmd "$CERBERO $CERBERO_ARGS gen-cache" | tee "${LOG_PATH}/4_cache.log"
+
+    - if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-sources-cache.outputs.cache-hit }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
+        key: ${{ steps.restore-cerbero-sources-cache.outputs.cache-primary-key }}
+
+    - if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
+        key: ${{ steps.restore-cerbero-deps-cache.outputs.cache-primary-key }}
+
+    - id: build-packages
+      working-directory: cerbero
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      env:
+        CI_PROJECT_NAME: cerbero
+        LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
+      run: |
+        mkdir -p "${LOG_PATH}"
+
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          cmd="$CERBERO $CERBERO_ARGS package --offline ${CERBERO_PACKAGE_ARGS} -o \"$(cygpath -am .)\" gstreamer-1.0"
+        else
+          cmd="$CERBERO $CERBERO_ARGS package --offline ${CERBERO_PACKAGE_ARGS} -o \"$(pwd)\" gstreamer-1.0"
+        fi
+
+        echo "::group::$cmd"
+        eval $cmd | tee "${LOG_PATH}/package.log"
+        echo "::endgroup::"
+
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          find ~+ -maxdepth 1 -name 'gstreamer-1.0-msvc*.msi' -exec sh -c 'echo runtime-msi=$(cygpath -aw "{}") >> $GITHUB_OUTPUT' \;
+          find ~+ -maxdepth 1 -name 'gstreamer-1.0-devel*.msi' -exec sh -c 'echo dev-msi=$(cygpath -aw "{}") >> $GITHUB_OUTPUT' \;
+        else
+          find ~+ -maxdepth 1 -name 'gstreamer-1.0-msvc*.msi' -exec sh -c 'echo runtime-msi=$(readlink -f "{}") >> $GITHUB_OUTPUT' \;
+          find ~+ -maxdepth 1 -name 'gstreamer-1.0-devel*.msi' -exec sh -c 'echo dev-msi=$(readlink -f "{}") >> $GITHUB_OUTPUT' \;
+        fi
+
+    - name: Annotate workflow run with GStreamer version
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        echo "::notice title=Built GStreamer version ${{ steps.cerbero-config.outputs.version }}::Created installer with Cerbero short sha ${{ steps.cerbero-config.outputs.cerbero-sha }}"
+
+    - uses: actions/upload-artifact@v4
+      if: ${{ steps.build-packages.outputs.runtime-msi || steps.build-packages.outputs.dev-msi }}
+      with:
+        name: GStreamer Installers
+        path: |
+          ${{ steps.build-packages.outputs.runtime-msi }}
+          ${{ steps.build-packages.outputs.dev-msi }}
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      if: ${{ always() && steps.cerbero-config.outcome == 'success' }}
+      with:
+        name: cerbero-logs
+        path: ${{ steps.cerbero-config.outputs.cerbero-home }}\logs

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,136 @@
+name: Install GStreamer with Cerbero on Windows
+description: Installs the GStreamer MSIs either from the URLs or local paths
+inputs:
+  runtime-installer-url:
+    description: 'URL of the GStreamer runtime installer'
+    required: false
+  development-installer-url:
+    description: 'URL of the GStreamer development installer'
+    required: false
+  runtime-installer-path:
+    description: 'Local path of the GStreamer runtime installer'
+    required: false
+  development-installer-path:
+    description: 'Local path of the GStreamer development installer'
+    required: false
+outputs:
+  install-dir:
+    description: 'GStreamer install directory'
+    value: ${{ steps.install-gstreamer.outputs.gstreamer-install-dir }}
+  plugin-dir:
+    description: 'GStreamer plugin directory'
+    value: ${{ steps.install-gstreamer.outputs.gstreamer-plugin-dir }}
+  bin-dir:
+    description: 'GStreamer bin directory'
+    value: ${{ steps.install-gstreamer.outputs.gstreamer-bin-dir }}
+
+runs:
+  using: "composite"
+  steps:
+    - if: ${{ runner.os != 'Windows'}}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        echo "Error: This action is only supported on Windows."
+        exit 1
+    # Mutual exclusive -- either set url or path for each.  Error if both or neither
+    # are set.  If path is set, verify the file exists.
+    - if: ${{ inputs.runtime-installer-url && inputs.runtime-installer-path }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        echo "Error: Cannot specify both runtime-installer-url and runtime-installer-path"
+        exit 1
+    - if: ${{ inputs.development-installer-url && inputs.development-installer-path }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        echo "Error: Cannot specify both development-installer-url and development-installer-path"
+        exit 2
+    - if: ${{ !inputs.runtime-installer-url && !inputs.runtime-installer-path }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        echo "Error: Must specify either runtime-installer-url or runtime-installer-path"
+        exit 3
+    - if: ${{ !inputs.development-installer-url && !inputs.development-installer-path }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        echo "Error: Must specify either development-installer-url or development-installer-path"
+        exit 4
+    - if: ${{ inputs.runtime-installer-path }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        if [[ ! -f "${{ inputs.runtime-installer-path }}" ]]; then
+          echo "Error: Runtime installer path does not exist: ${{ inputs.runtime-installer-path }}"
+          exit 5
+        fi
+    - if: ${{ inputs.development-installer-path }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        if [[ ! -f "${{ inputs.development-installer-path }}" ]]; then
+          echo "Error: Development installer path does not exist: ${{ inputs.development-installer-path }}"
+          exit 6
+        fi
+
+    # If the URL is provided, download the MSI, set path.
+    # This will error out if the file is missing.
+    - if: ${{ !inputs.runtime-installer-path && runner.os == 'Windows' }}
+      id: download-runtime
+      name: Download GStreamer Runtime MSI
+      shell: powershell
+      run: |
+        $msi_path = "$(( $pwd ))\gstreamer-runtime.msi"
+        Invoke-WebRequest -Uri "${{ inputs.runtime-installer-url }}" -OutFile "$msi_path"
+        echo "msi-path=$msi_path" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+        echo "::notice title=GStreamer runtime installer downloaded::Downloaded GStreamer runtime installer from ${{ inputs.runtime-installer-url }}"
+    - if: ${{ !inputs.development-installer-path && runner.os == 'Windows' }}
+      id: download-development
+      name: Download GStreamer Development MSI
+      shell: powershell
+      run: |
+        $msi_path = "$(( $pwd ))\gstreamer-development.msi"
+        Invoke-WebRequest -Uri "${{ inputs.development-installer-url }}" -OutFile "$msi_path"
+        echo "msi-path=$msi_path" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+        echo "::notice title=GStreamer development installer downloaded::Downloaded GStreamer development installer from ${{ inputs.development-installer-url }}"  
+
+    # Set the local paths favoring if the download happened
+    - id: msi-path
+      if: ${{ runner.os == 'Windows' }}
+      shell: powershell
+      run: |
+        # If the download happened, use the downloaded path, else use the input path
+        $runtime = "${{ steps.download-development.outputs.msi-path }}"
+        if ($runtime -eq "") {
+          $runtime = "${{ inputs.runtime-installer-path }}"
+        }
+        $development = "${{ steps.download-development.outputs.msi-path }}"
+        if ($development -eq "") {
+          $development = "${{ inputs.development-installer-path }}"
+        }
+        echo "runtime=$runtime" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+        echo "development=$development" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Install GStreamer
+      if: ${{ runner.os == 'Windows' }}
+      id: install-gstreamer
+      shell: powershell
+      env:
+        RUNTIME_MSI: ${{ steps.msi-path.outputs.runtime }}
+        DEVELOPMENT_MSI: ${{ steps.msi-path.outputs.development }}
+      run: |
+        $GSTREAMER_INSTALL_DIR="${{ runner.temp }}\gstreamer"
+        $GSTREAMER_ROOT="$GSTREAMER_INSTALL_DIR\1.0\msvc_x86_64"
+        $GSTREAMER_BIN="$GSTREAMER_ROOT\bin"
+        echo "$GSTREAMER_BIN" | Out-File -FilePath $Env:GITHUB_PATH -Append -Encoding utf8
+        echo "PKG_CONFIG_PATH=$GSTREAMER_ROOT\lib\pkgconfig;$env:PKG_CONFIG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8
+
+        echo "gstreamer-bin-dir=$GSTREAMER_BIN" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+        echo "gstreamer-install-dir=$GSTREAMER_INSTALL_DIR" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+        echo "gstreamer-plugin-dir=$GSTREAMER_ROOT" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+
+        if ($RUNTIME_MSI) {
+          echo "Installing GStreamer Runtime"
+          Start-Process msiexec -ArgumentList '/i `"$RUNTIME_MSI`" ADDLOCAL=ALL INSTALLDIR=`"$GSTREAMER_INSTALL_DIR`" /qn' -NoNewWindow -PassThru -Wait
+
+          if ($DEVELOPMENT_MSI) {
+            echo "Installing GStreamer Development"
+            Start-Process msiexec -ArgumentList '/i `"$DEVELOPMENT_MSI`" ADDLOCAL=ALL INSTALLDIR=`"$GSTREAMER_INSTALL_DIR`" /qn' -NoNewWindow -PassThru -Wait
+          }
+        }

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -179,7 +179,7 @@ runs:
     - id: build-packages
       if: ${{ !steps.check-installer-exists.outputs.runtime-path || !steps.check-installer-exists.outputs.dev-path }}
       name: Build GStreamer with Cerbero
-      uses: ./.cerbero-action/.github/actions/build
+      uses: ./.ca/.github/actions/build
       with:
         config: ${{ inputs.config }}
         cerbero-args: ${{ inputs.cerbero-args }}
@@ -224,12 +224,7 @@ runs:
 
     - id: install
       name: Install GStreamer
-      uses: ./.cerbero-action/.github/actions/install
+      uses: ./.ca/.github/actions/install
       with:
         runtime-installer-path: ${{ steps.select-path.outputs.runtime-installer-path }}
         development-installer-path: ${{ steps.select-path.outputs.development-installer-path }}
-
-    - name: Cleanup Cerbero
-      if: ${{ always() && inputs.cleanup == 'true' && steps.get-cerbero.outcome != 'skipped'}}
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      run: rm -rf cerbero

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,235 @@
+name: Setup GStreamer
+description: Downloads or Builds and then installs GStreamer on Windows
+inputs:
+  cerbero-repo:
+    description: 'Repository to use for Cerbero'
+    required: false
+    default: ${{ github.action_repository || github.repository }}
+  cerbero-ref:
+    description: 'Ref to use for Cerbero'
+    required: false
+    default: ${{ github.action_ref || github.ref }}
+  config:
+    description: 'Name of the configuration file to use'
+    required: false
+    default: ''
+  cerbero-args:
+    description: 'Additional args to pass to Cerbero'
+    required: false
+    default: ''
+  cerbero-package-args:
+    description: 'Additional args to pass to Cerbero package'
+    required: false
+    default: ''
+  s3-download-paths:
+    description: 'S3 paths to download from'
+    required: false
+  s3-upload-path:
+    description: 'S3 path to upload to'
+    required: false
+  gst-plugins-rs-repo:
+    description: 'Repository to use for gst-plugins-rs'
+    required: false
+  gst-plugins-rs-ref:
+    description: 'Ref/tag to use for gst-plugins-rs'
+    required: false
+  cleanup:
+    description: 'Whether to clean the Cerbero build directory'
+    required: false
+    default: 'true'
+  no-cache:
+    description: 'Whether to disable restoring from cache'
+    required: false
+    default: 'false'
+outputs:
+  gstreamer-version:
+    description: 'GStreamer version'
+    value: ${{ steps.build.outputs.gstreamer-version }}
+  cerbero-short-sha:
+    description: 'Short SHA of the Cerbero checkout'
+    value: ${{ steps.version-info.outputs.cerbero-short-sha }}
+  install-dir:
+    description: 'GStreamer install directory'
+    value: ${{ steps.install.outputs.gstreamer-install-dir }}
+
+runs:
+  using: "composite"
+  steps:
+
+    - if: runner.os == 'Windows'
+      name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        # release = false: use existing installation
+        # path-type: cerbero requires 'inherit' path type
+        # tie 'cache' to the input arg
+        msystem: UCRT64
+        path-type: inherit
+        release: false
+        cache:     ${{ inputs.no-cache != 'true' }}
+        install: >-
+          mingw-w64-ucrt-x86_64-jq
+          m4
+          mingw-w64-ucrt-x86_64-gcc-libs
+          mingw-w64-ucrt-x86_64-libwinpthread-git
+          bison
+          mingw-w64-ucrt-x86_64-diffutils
+          flex
+          mingw-w64-ucrt-x86_64-gperf
+          mingw-w64-ucrt-x86_64-autotools
+          mingw-w64-ucrt-x86_64-ninja
+          mingw-w64-ucrt-x86_64-perl
+
+    - if: runner.os == 'Windows'
+      name: Enable long file paths
+      shell: powershell
+      run: |
+        New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
+    - if: runner.os == 'Windows'
+      # These are seen in the cerbero-uninstalled.ps1 script as a CLI arg
+      name: Set Extra MSYS2 flags for UCRT64 Environment
+      shell: powershell
+      run: |
+        Add-Content "C:\msys64\ucrt64.ini" "`nCHERE_INVOKING=1"
+        Add-Content "C:\msys64\ucrt64.ini" "`nMSYS2_NOSTART=yes"
+        Add-Content "C:\msys64\ucrt64.ini" "`nMSYS=winsymlinks:nativestrict"
+
+    - if: runner.os == 'Windows'
+      name: Set Git 'core.autocrlf = false'
+      shell: msys2 -eo pipefail {0}
+      run: git config --global core.autocrlf false
+
+    - name: Python >= 3.10
+      uses: actions/setup-python@v5
+      with:
+        # cerbero requires >=3.10
+        python-version: '>=3.10'
+
+    - name: Clone Cerbero
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: |
+        git clone --depth=1 --branch ${{ inputs.cerbero-ref }} ${{ inputs.cerbero-repo }} cerbero
+
+    - id: version-info
+      name: Gather Version Information
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      working-directory: cerbero
+      env:
+        CI_PROJECT_NAME: cerbero
+      run: |
+        # Get GStreamer/cerbero version info and installer filenames
+        gstreamer_version=$(./cerbero-uninstalled packageinfo gstreamer-1.0 | awk '/Version:/ {print $2}')
+        echo "gstreamer-version=${gstreamer_version}" | tee -a $GITHUB_OUTPUT
+
+        cerbero_short_sha=$(git -C cerbero rev-parse --short HEAD)
+        echo "cerbero-short-sha=${cerbero_short_sha}" | tee -a $GITHUB_OUTPUT
+
+        echo "runtime-msi-filename=gstreamer-1.0-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
+        echo "dev-msi-filename=gstreamer-1.0-devel-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
+
+    - id: check-installer-exists
+      if: ${{ inputs.force != 'true' && inputs.s3-download-paths }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      continue-on-error: true
+      env:
+        S3_DOWNLOAD_PATHS: ${{ inputs.s3-download-paths }}
+        RUNTIME_MSI_FILENAME: ${{ steps.version-info.outputs.runtime-msi-filename }}
+        DEV_MSI_FILENAME: ${{ steps.version-info.outputs.dev-msi-filename }}
+      run: |
+        # Check installer already exists in S3
+
+        runtime_msi="null"
+        dev_msi="null"
+
+        for download_path in ${S3_DOWNLOAD_PATHS}; do
+          echo "Checking for installers under ${download_path}"
+
+          bucket=$(echo ${download_path} | cut -d/ -f3)
+          prefix=$(echo ${download_path} | cut -d/ -f4-)
+
+          if [ "$runtime_msi" = "null" ]; then
+            echo "Checking for runtime installer under s3://${bucket}/${prefix}/"
+            runtime_msi=$(aws s3api list-objects-v2 --bucket "${bucket}" --prefix "${prefix}/" --query 'Contents[].Key' | jq -r 'if type!="array" then [] else . end | sort_by(length) | map(select(endswith("'"${RUNTIME_MSI_FILENAME}"'"))) | .[0]')
+            if [ "$runtime_msi" != "null" ]; then
+              s3_uri="s3://${bucket}/${runtime_msi}"
+              aws s3 cp --no-progress "${s3_uri}" "cerbero/$(basename ${runtime_msi})"
+              echo "runtime-path=cerbero/$(basename ${runtime_msi})" | tee -a $GITHUB_OUTPUT
+              echo "::notice title=GStreamer Runtime Installer Downloaded From S3::Location: ${s3_uri}"
+            fi
+          fi
+
+          if [ "$dev_msi" = "null" ]; then
+            echo "Checking for development installer under s3://${bucket}/${prefix}/"
+            dev_msi=$(aws s3api list-objects-v2 --bucket "${bucket}" --prefix "${prefix}/" --query 'Contents[].Key' | jq -r 'if type!="array" then [] else . end | sort_by(length) | map(select(endswith("'"${DEV_MSI_FILENAME}"'"))) | .[0]')
+            if [ "$dev_msi" != "null" ]; then
+              s3_uri="s3://${bucket}/${dev_msi}"
+              aws s3 cp --no-progress "${s3_uri}" "cerbero/$(basename ${dev_msi})"
+              echo "dev-path=cerbero/$(basename ${dev_msi})" | tee -a $GITHUB_OUTPUT
+              echo "::notice title=GStreamer Development Installer Downloaded From S3::Location: ${s3_uri}"
+            fi
+          fi
+
+          if [ "$runtime_msi" != "null" ] && [ "$dev_msi" != "null" ]; then
+            break
+          fi
+        done
+
+      # If either installer was not found, run a build.
+    - id: build-packages
+      if: ${{ !steps.check-installer-exists.outputs.runtime-path || !steps.check-installer-exists.outputs.dev-path }}
+      name: Build GStreamer with Cerbero
+      uses: ./.cerbero-action/.github/actions/build
+      with:
+        config: ${{ inputs.config }}
+        cerbero-args: ${{ inputs.cerbero-args }}
+        cerbero-package-args: ${{ inputs.cerbero-package-args }}
+        cerbero-package-origin: ${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.version-info.outputs.cerbero-short-sha }}
+        gst-plugins-rs-repo: ${{ inputs.gst-plugins-rs-repo }}
+        gst-plugins-rs-ref: ${{ inputs.gst-plugins-rs-ref }}
+        no-cache: ${{ inputs.no-cache }}
+
+      # If the build ran, upload the result (if possible).
+    - id: upload-packages
+      if: ${{ steps.build-packages.outcome == 'success' && inputs.s3-upload-path }}
+      name: Upload newly-built GStreamer installers to S3
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      working-directory: cerbero
+      env:
+        RUNTIME_MSI_FILENAME: ${{ steps.version-info.outputs.runtime-msi-filename }}
+        DEV_MSI_FILENAME: ${{ steps.version-info.outputs.dev-msi-filename }}
+      run: |
+        echo "::group::Upload packages"
+
+        upload_path="${{ inputs.s3-upload-path }}/${RUNTIME_MSI_FILENAME}"
+        aws s3 cp --no-progress "$(cygpath -u '${{ steps.build-packages.outputs.runtime-installer-path }}')" "${upload_path}"
+        echo "::notice title=GStreamer Runtime Installer Uploaded to S3::Location: ${upload_path}"
+        echo "runtime-msi=${upload_path}" | tee -a $GITHUB_OUTPUT
+
+        upload_path="${{ inputs.s3-upload-path }}/${DEV_MSI_FILENAME}"
+        aws s3 cp --no-progress "$(cygpath -u '${{ steps.build-packages.outputs.devel-installer-path }}')" "${upload_path}"
+        echo "::notice title=GStreamer Development Installer Uploaded to S3::Location: ${upload_path}"
+        echo "dev-msi=${upload_path}" | tee -a $GITHUB_OUTPUT
+
+        echo "::endgroup::"
+
+    - id: select-path
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      env:
+        RUNTIME_PATH: ${{ steps.build-packages.outputs.runtime-installer-path || steps.check-installer-exists.outputs.runtime-path }}
+        DEV_PATH: ${{ steps.build-packages.outputs.devel-installer-path || steps.check-installer-exists.outputs.dev-path }}
+      run: |
+        echo "runtime-installer-path=${RUNTIME_PATH}" | tee -a $GITHUB_OUTPUT
+        echo "development-installer-path=${DEV_PATH}" | tee -a $GITHUB_OUTPUT
+
+    - id: install
+      name: Install GStreamer
+      uses: ./.cerbero-action/.github/actions/install
+      with:
+        runtime-installer-path: ${{ steps.select-path.outputs.runtime-installer-path }}
+        development-installer-path: ${{ steps.select-path.outputs.development-installer-path }}
+
+    - name: Cleanup Cerbero
+      if: ${{ always() && inputs.cleanup == 'true' && steps.get-cerbero.outcome != 'skipped'}}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: rm -rf cerbero

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,3 +35,4 @@ jobs:
           cerbero-args: '--clocktime --timestamps -v visualstudio'
           config: 'win64.cbc'
           no-cache: ${{ inputs.no-cache == true }}
+          cerbero-action-ref: ${{ github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,4 +32,6 @@ jobs:
         with:
           cerbero-repo: ${{ inputs.cerbero-repo }}
           cerbero-ref: ${{ inputs.cerbero-ref }}
+          cerbero-args: '--clocktime --timestamps -v visualstudio'
+          config: 'win64.cbc'
           no-cache: ${{ inputs.no-cache == true }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# cerbero-action
+# Cerbero Action (for GStreamer)
+
+This GitHub action facilitates configuring a workflow with a specific installation of GStreamer.  If a specific version is not found ready to download, this action will also attempt to build GStreamer using the provided configuration arguments.  Once GStreamer is either downloaded or built, it is installed and the OS environment configured for its use.
+
+> NOTE: this has currently been tested on Windows runners; Linux support is not fully supported at this time.
+
+## Usage
+
+```yaml
+- uses: laerdallabs/cerbero-action@main
+  with:
+    cerbero-repo:
+      # Repository to use for Cerbero
+      # required: false
+      # default: https://gitlab.freedesktop.org/gstreamer/cerbero.git
+    cerbero-ref:
+      # description: 'Ref to use for Cerbero'
+      # required: false
+      # default: main
+    config:
+      # description: 'Name of the configuration file to use'
+      # required: false
+    cerbero-args:
+      # description: 'Additional args to pass to Cerbero'
+      # required: false
+      # default: '--clocktime --timestamps'
+    cerbero-package-args:
+      # description: 'Additional args to pass to Cerbero package'
+      # required: false
+      # default: ''
+    cleanup:
+      # description: 'Whether to clean the Cerbero build directory'
+      # required: false
+      # default: 'true'
+    no-cache:
+      # description: 'Whether to disable restoring from cache'
+      # required: false
+      # default: 'false'
+    s3-download-paths:
+      # description: 'S3 paths to download from'
+      # required: false
+    s3-upload-path:
+      # description: 'S3 path to upload to'
+      # required: false
+    gst-plugins-rs-repo:
+      # description: 'Repository to use for gst-plugins-rs'
+      # required: false
+    gst-plugins-rs-ref:
+      # description: 'Ref/tag to use for gst-plugins-rs'
+      # required: false
+```
+
+## License
+
+The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Setup GStreamer
-description: Installs GStreamer by either building via Cerbero or downloading the installer.
+description: Setup GStreamer by either downloading or building via Cerbero.
 inputs:
   cerbero-repo:
     description: 'Repository to use for Cerbero'
@@ -20,6 +20,10 @@ inputs:
     description: 'Additional args to pass to Cerbero package'
     required: false
     default: ''
+  cerbero-action-ref:
+    description: 'Branch/tag/ref to use for cloning cerbero-action'
+    required: false
+    default: main
   cleanup:
     description: 'Whether to clean the Cerbero build directory'
     required: false
@@ -58,12 +62,13 @@ runs:
       # the 'uses' will resolve to the actions contained in this repo.
       with:
         repository: laerdallabs/cerbero-action
-        path: .cerbero-action
+        ref: ${{ inputs.cerbero-action-ref }}
+        path: .ca
         fetch-depth: 1
 
     - name: Run Setup Action
       id: setup-action
-      uses: ./.cerbero-action/.github/actions/setup
+      uses: ./.ca/.github/actions/setup
       with:
         cerbero-repo: ${{ inputs.cerbero-repo }}
         cerbero-ref: ${{ inputs.cerbero-ref }}
@@ -76,3 +81,8 @@ runs:
         s3-upload-path: ${{ inputs.s3-upload-path }}
         gst-plugins-rs-repo: ${{ inputs.gst-plugins-rs-repo }}
         gst-plugins-rs-ref: ${{ inputs.gst-plugins-rs-ref }}
+
+    - name: Cleanup Cerbero
+      if: ${{ always() && inputs.cleanup == 'true' }}
+      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
+      run: rm -rf cerbero

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: Build GStreamer with Cerbero (on Windows)
-description: Uses the GStreamer Cerbero build aggregator to build GStreamer (MSI packages) on the local toolchain
+name: Setup GStreamer
+description: Installs GStreamer by either building via Cerbero or downloading the installer.
 inputs:
   cerbero-repo:
     description: 'Repository to use for Cerbero'
@@ -28,285 +28,51 @@ inputs:
     description: 'Whether to disable restoring from cache'
     required: false
     default: 'false'
+  s3-download-paths:
+    description: 'S3 paths to download from'
+    required: false
+  s3-upload-path:
+    description: 'S3 path to upload to'
+    required: false
+  gst-plugins-rs-repo:
+    description: 'Repository to use for gst-plugins-rs'
+    required: false
+  gst-plugins-rs-ref:
+    description: 'Ref/tag to use for gst-plugins-rs'
+    required: false
 outputs:
   gstreamer-version:
     description: 'GStreamer version'
-    value: ${{ steps.version-info.outputs.gstreamer-version }}
+    value: ${{ steps.setup-action.outputs.gstreamer-version }}
   cerbero-short-sha:
     description: 'Short SHA of the Cerbero checkout'
-    value: ${{ steps.version-info.outputs.cerbero-short-sha }}
-  cerbero-path:
-    description: 'Path to the Cerbero checkout'
-    value: ${{ inputs.cleanup != 'true' && 'cerbero' }}
-  runtime-package-path:
-    description: 'Location of the GStreamer runtime package'
-    value: ${{ steps.build-packages.outputs.runtime-package }}
-  devel-package-path:
-    description: 'Location of the GStreamer development package'
-    value: ${{ steps.build-packages.outputs.dev }}
+    value: ${{ steps.setup-action.outputs.cerbero-short-sha }}
+  install-dir:
+    description: 'GStreamer install directory'
+    value: ${{ steps.setup-action.outputs.install-dir }}
 runs:
   using: "composite"
   steps:
-    - name: Python >= 3.10
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v4
+      # Checkout the action so that when another repo uses this action,
+      # the 'uses' will resolve to the actions contained in this repo.
       with:
-        # cerbero requires >=3.10
-        python-version: '>=3.10'
+        repository: laerdallabs/cerbero-action
+        path: .cerbero-action
+        fetch-depth: 1
 
-    - if: runner.os == 'Windows'
-      name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
+    - name: Run Setup Action
+      id: setup-action
+      uses: ./.cerbero-action/.github/actions/setup
       with:
-        # release = false: use existing installation
-        # path-type: cerbero requires 'inherit' path type
-        # tie 'cache' to the input arg
-        release:   false
-        msystem:   UCRT64
-        path-type: inherit
-        cache:     ${{ inputs.no-cache != 'true' }}
-        install: >-
-          mingw-w64-ucrt-x86_64-jq
-          m4
-          mingw-w64-ucrt-x86_64-gcc-libs
-          mingw-w64-ucrt-x86_64-libwinpthread-git
-          bison
-          mingw-w64-ucrt-x86_64-diffutils
-          flex
-          mingw-w64-ucrt-x86_64-gperf
-          mingw-w64-ucrt-x86_64-autotools
-          mingw-w64-ucrt-x86_64-ninja
-          mingw-w64-ucrt-x86_64-perl
-
-    - if: runner.os == 'Windows'
-      name: Enable long file paths
-      shell: powershell
-      run: |
-        New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
-
-    - if: runner.os == 'Windows'
-      # These are seen in the cerbero-uninstalled.ps1 script as a CLI arg
-      name: Set Extra MSYS2 flags for UCRT64 Environment
-      shell: powershell
-      run: |
-        Add-Content "C:\msys64\ucrt64.ini" "`nCHERE_INVOKING=1"
-        Add-Content "C:\msys64\ucrt64.ini" "`nMSYS2_NOSTART=yes"
-        Add-Content "C:\msys64\ucrt64.ini" "`nMSYS=winsymlinks:nativestrict"
-
-    - if: runner.os == 'Windows'
-      name: Set Git 'core.autocrlf = false'
-      shell: msys2 -eo pipefail {0}
-      run: git config --global core.autocrlf false
-
-    - name: Clone Cerbero
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      run: |
-        git clone --depth=1 --branch ${{ inputs.cerbero-ref }} ${{ inputs.cerbero-repo }} cerbero
-
-    - name: Run Bootstrap
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      working-directory: cerbero
-      run: |
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          powershell.exe ./tools/bootstrap-windows.ps1
-        else
-          ./tools/bootstrap-debian.sh
-        fi
-
-    - id: version-info
-      name: Gather Version Information
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      working-directory: cerbero
-      env:
-        CI_PROJECT_NAME: cerbero
-      run: |
-        # Get GStreamer/cerbero version info and installer filenames
-        gstreamer_version=$(./cerbero-uninstalled packageinfo gstreamer-1.0 | awk '/Version:/ {print $2}')
-        echo "gstreamer-version=${gstreamer_version}" | tee -a $GITHUB_OUTPUT
-
-        cerbero_short_sha=$(git -C cerbero rev-parse --short HEAD)
-        echo "cerbero-short-sha=${cerbero_short_sha}" | tee -a $GITHUB_OUTPUT
-
-        echo "runtime-msi-filename=gstreamer-1.0-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
-        echo "dev-msi-filename=gstreamer-1.0-devel-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
-
-    - id: cerbero-config
-      name: Configure Cerbero Build
-      working-directory: cerbero
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      env:
-        CERBERO_PATH: cerbero
-        CERBERO_HOME: cerbero-build
-        CERBERO_SOURCES: cerbero-sources
-        CERBERO_ARGS: ${{ inputs.cerbero-args }}
-        CERBERO_PACKAGE_ARGS: ${{ inputs.cerbero-package-args }}
-        CERBERO_PACKAGE_ORIGIN: ${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.version-info.outputs.cerbero-short-sha }}
-      run: |
-        # Set up Cerbero configuration
-        echo "cerbero-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-        echo "cerbero-home=${CERBERO_PATH}/${CERBERO_HOME}" >> $GITHUB_OUTPUT
-        echo "cerbero-sources=${CERBERO_PATH}/${CERBERO_SOURCES}" >> $GITHUB_OUTPUT
-
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          echo "full-log-path=$(cygpath -au .)/${CERBERO_HOME}/logs" >> $GITHUB_OUTPUT
-          pwd_native=$(cygpath -am .)
-        else
-          echo "full-log-path=$(pwd)/${CERBERO_HOME}/logs" >> $GITHUB_OUTPUT
-          pwd_native=$(pwd)
-        fi
-
-        echo "home_dir = \"${pwd_native}/${CERBERO_HOME}\"" > localconf.cbc
-        echo "local_sources = \"${pwd_native}/${CERBERO_SOURCES}\"" >> localconf.cbc
-        echo "vs_install_version = \"vs17\"" >> localconf.cbc
-        echo "num_of_cpus = ${NUMBER_OF_PROCESSORS:-$(nproc --all)}" >> localconf.cbc
-        echo "package_origin = \"${CERBERO_PACKAGE_ORIGIN}\"" >> localconf.cbc
-        cat localconf.cbc
-
-        git clean -xdf -e localconf.cbc -e "${CERBERO_SOURCES}"
-
-        cerbero_cmd="./cerbero-uninstalled"
-        if [ -n "${{ inputs.config }}" ]; then
-          cerbero_cmd="${cerbero_cmd} -c config/${{ inputs.config }}"
-        fi
-
-        echo "CERBERO=${cerbero_cmd} -c localconf.cbc" >> $GITHUB_ENV
-        echo "CERBERO_ARGS=${CERBERO_ARGS}" >> $GITHUB_ENV
-        echo "CERBERO_PACKAGE_ARGS=${CERBERO_PACKAGE_ARGS}" >> $GITHUB_ENV
-
-        config_hash=$(echo "${CERBERO_ARGS}${{ inputs.config }}" | sha256sum | cut -d' ' -f1)
-        echo "config-hash=${config_hash}" >> $GITHUB_OUTPUT
-
-    - id: restore-cerbero-sources-cache
-      if: ${{ inputs.no-cache != 'true' }}
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
-        key: |
-          cerbero-sources-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}
-        restore-keys: |
-          cerbero-sources-${{ steps.version-info.outputs.gstreamer-version }}-
-          cerbero-sources-
-
-    - id: restore-cerbero-deps-cache
-      if: ${{ inputs.no-cache != 'true' }}
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ steps.cerbero-config.outputs.cerbero-home }}/cerbero-deps.tar.xz
-        key: |
-          ${{ runner.os }}-cerbero-deps-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ steps.cerbero-config.outputs.config-hash }}-${{ runner.name }}
-        restore-keys: |
-          ${{ runner.os }}-cerbero-deps-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ steps.cerbero-config.outputs.config-hash }}-
-
-    - if: ${{ steps.restore-cerbero-deps-cache.outputs.cache-matched-key }}
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      run: |
-        # Restore Cerbero dependencies
-        deps_file='${{ steps.cerbero-config.outputs.cerbero-home }}/cerbero-deps.tar.xz'
-
-        if [ ! -f "$deps_file" ]; then
-          exit 0
-        fi
-
-        echo "::group::Unpacking Cerbero Deps"
-        tar -xJf "${deps_file}" -C '${{ steps.cerbero-config.outputs.cerbero-home }}'
-        rm -f "${deps_file}"
-        ls -l '${{ steps.cerbero-config.outputs.cerbero-home }}'
-        echo "::endgroup::"
-
-    - id: build-gstreamer-deps
-      working-directory: cerbero
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      env:
-        CI_PROJECT_NAME: cerbero
-        LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
-        FETCH_ARGS: --jobs=4
-      run: |
-        # Build Cerbero Deps
-        mkdir -p "${LOG_PATH}"
-
-        group_cmd () {
-          echo "::group::$1"
-          eval $1
-          echo "::endgroup::"
-        }
-
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          group_cmd "pacman -Q" | tee "${LOG_PATH}/0_pacman.log"
-        fi
-
-        # Build deps for all gstreamer recipes and any recipes that build gstreamer
-        # plugins (and hence compile against gstreamer)
-        build_deps="gstreamer-1.0 gst-plugins-base-1.0 gst-plugins-good-1.0
-            gst-plugins-bad-1.0 gst-plugins-ugly-1.0 gst-rtsp-server-1.0
-            gst-devtools-1.0 gst-editing-services-1.0 libnice gst-plugins-rs
-            gst-libav-1.0"
-        more_deps="glib-networking pkg-config"
-
-        group_cmd "$CERBERO $CERBERO_ARGS show-config" | tee "${LOG_PATH}/1_config.log"
-        group_cmd "$CERBERO $CERBERO_ARGS fetch-bootstrap $FETCH_ARGS" | tee "${LOG_PATH}/2_bootstrap.log"
-        group_cmd "$CERBERO $CERBERO_ARGS fetch-package $FETCH_ARGS --deps gstreamer-1.0" | tee -a "${LOG_PATH}/2_bootstrap.log"
-        group_cmd "$CERBERO $CERBERO_ARGS bootstrap --offline --system=no" | tee -a "${LOG_PATH}/2_bootstrap.log"
-        group_cmd "$CERBERO $CERBERO_ARGS build-deps --offline $build_deps" | tee "${LOG_PATH}/3_build-deps.log"
-        group_cmd "$CERBERO $CERBERO_ARGS build --offline $more_deps" | tee -a "${LOG_PATH}/3_build-deps.log"
-        group_cmd "$CERBERO $CERBERO_ARGS gen-cache" | tee "${LOG_PATH}/4_cache.log"
-
-    - if: ${{ inputs.no-cache != 'true' && steps.build-gstreamer-deps.outcome == 'success' && ! steps.restore-cerbero-sources-cache.outputs.cache-hit }}
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
-        key: ${{ steps.restore-cerbero-sources-cache.outputs.cache-primary-key }}
-
-    - if: ${{ inputs.no-cache != 'true' && steps.build-gstreamer-deps.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ steps.cerbero-config.outputs.cerbero-home }}/cerbero-deps.tar.xz
-        key: ${{ steps.restore-cerbero-deps-cache.outputs.cache-primary-key }}
-
-    - id: build-packages
-      working-directory: cerbero
-      shell: ${{ runner.os == 'Windows'  && 'msys2 -eo pipefail {0}' || 'bash' }}
-      env:
-        CI_PROJECT_NAME: cerbero
-        LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
-      run: |
-        mkdir -p "${LOG_PATH}"
-
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          cmd="$CERBERO $CERBERO_ARGS package --offline ${CERBERO_PACKAGE_ARGS} -o \"$(cygpath -am .)\" gstreamer-1.0"
-        else
-          cmd="$CERBERO $CERBERO_ARGS package --offline ${CERBERO_PACKAGE_ARGS} -o \"$(pwd)\" gstreamer-1.0"
-        fi
-
-        echo "::group::$cmd"
-        eval $cmd | tee "${LOG_PATH}/5_package.log"
-        echo "::endgroup::"
-
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          find ~+ -maxdepth 1 -name 'gstreamer-1.0-msvc*.msi' -exec sh -c 'echo runtime-msi=$(cygpath -aw "{}") >> $GITHUB_OUTPUT' \;
-          find ~+ -maxdepth 1 -name 'gstreamer-1.0-devel*.msi' -exec sh -c 'echo dev-msi=$(cygpath -aw "{}") >> $GITHUB_OUTPUT' \;
-        else
-          find ~+ -maxdepth 1 -name 'gstreamer-1.0-msvc*.msi' -exec sh -c 'echo runtime-msi=$(readlink -f "{}") >> $GITHUB_OUTPUT' \;
-          find ~+ -maxdepth 1 -name 'gstreamer-1.0-devel*.msi' -exec sh -c 'echo dev-msi=$(readlink -f "{}") >> $GITHUB_OUTPUT' \;
-        fi
-
-    - uses: actions/upload-artifact@v4
-      if: ${{ steps.build-packages.outputs.runtime-msi || steps.build-packages.outputs.dev-msi }}
-      with:
-        name: GStreamer Installers
-        path: |
-          ${{ steps.build-packages.outputs.runtime-msi }}
-          ${{ steps.build-packages.outputs.dev-msi }}
-
-    - name: Upload logs
-      uses: actions/upload-artifact@v4
-      if: ${{ always() && steps.cerbero-config.outcome == 'success' }}
-      with:
-        name: cerbero-logs
-        path: ${{ steps.cerbero-config.outputs.cerbero-home }}/logs
-
-    - name: Upload builddir on build failure
-      uses: actions/upload-artifact@v4
-      if: ${{ always() && steps.build-packages.outcome != 'success' }}
-      with:
-        name: build-gstreamer-deps
-        path: ${{ steps.cerbero-config.outputs.cerbero-home }}
+        cerbero-repo: ${{ inputs.cerbero-repo }}
+        cerbero-ref: ${{ inputs.cerbero-ref }}
+        cerbero-args: ${{ inputs.cerbero-args }}
+        cerbero-package-args: ${{ inputs.cerbero-package-args }}
+        config: ${{ inputs.config }}
+        cleanup: ${{ inputs.cleanup }}
+        no-cache: ${{ inputs.no-cache }}
+        s3-download-paths: ${{ inputs.s3-download-paths }}
+        s3-upload-path: ${{ inputs.s3-upload-path }}
+        gst-plugins-rs-repo: ${{ inputs.gst-plugins-rs-repo }}
+        gst-plugins-rs-ref: ${{ inputs.gst-plugins-rs-ref }}


### PR DESCRIPTION
Importing from blinemedical/cerbero the latest effort to split the monolithic action into separable pieces in a way that is still able to be used by downstream projects to obtain gstreamer of a particular version or build it, then install it, so that the downstream project can use this in a workflow.